### PR TITLE
Fix: History browsing in CLI

### DIFF
--- a/cubeclient/cli.go
+++ b/cubeclient/cli.go
@@ -76,6 +76,8 @@ func loadSuggestions() {
 
 func startCli() {
 
+	initialHistoryCapacity := 10
+	history := make([]string, 0, initialHistoryCapacity)
 	loadSuggestions()
 
 	for {
@@ -87,11 +89,14 @@ func startCli() {
 			prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
 			prompt.OptionSelectedSuggestionTextColor(prompt.DarkGray),
 			prompt.OptionDescriptionTextColor(prompt.DarkGray),
-			prompt.OptionSuggestionBGColor(prompt.DarkGray))
+			prompt.OptionSuggestionBGColor(prompt.DarkGray),
+			prompt.OptionHistory(history))
 
 		if strings.ToLower(cmd) == "exit" {
 			break
 		}
+
+		history = append(history, cmd)
 		reply, err := executeCommand(cmd)
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())


### PR DESCRIPTION
This PR fixes history navigation bug in cubeclient CLI. 
Issue: [#5: History browsing in CLI ](https://github.com/bahadrix/CardinalityCube/issues/5)

**Problem:**
A new instance of prompt is created in each iteration of [the for-loop](https://github.com/bahadrix/CardinalityCube/commit/13e6946e494de6b396c5f084e288ee7387e70ab2#diff-3330f395f15361c8ece63ae257bc45d5R81). Therefore, command history is not preserved between consecutive commands. 

**Proposed Solution:**
`go-prompt` package has [an API to inject history array](https://pkg.go.dev/github.com/c-bata/go-prompt?tab=doc#OptionHistory) explicitly. I created an empty string array outside of the for-loop, and inject this array to prompt instance by using `OptionHistory` function. In this way, CLI is able to store history of user commands between for-loop iterations.

**Alternative:**
Instead of using `prompt.Input()`, we can replace for-loop with `prompt.New()` and `startCli()` becomes:

```go
func startCli() {

	loadSuggestions()

	p := prompt.New(Executor,
		autoComplete,
		prompt.OptionPrefix(fmt.Sprintf("%s> ", serverAddress)),
		prompt.OptionTitle("Cardinality Cube Server"),
		prompt.OptionPrefixTextColor(prompt.DarkBlue),
		prompt.OptionPreviewSuggestionTextColor(prompt.Blue),
		prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
		prompt.OptionSelectedSuggestionTextColor(prompt.DarkGray),
		prompt.OptionDescriptionTextColor(prompt.DarkGray),
		prompt.OptionSuggestionBGColor(prompt.DarkGray))

	p.Run()

}

func Executor(s string) {
	s = strings.TrimSpace(s)
	if s == "" {
		return
	} else if strings.ToLower(s) == "exit" {
		os.Exit(0)
		return
	}

	reply, err := executeCommand(s)
	if err != nil {
		fmt.Printf("ERROR: %s\n", err.Error())
	} else {
		fmt.Printf("%s\n", reply)
	}

	return
}
```

In this way, `go-prompt` package manages command history and other stuff itself. However, it does not provide a way to exit gracefully. Author of `go-prompt` discusses this problem [in this comment](https://github.com/c-bata/go-prompt/issues/9#issuecomment-326724362). 